### PR TITLE
Since now there is the superbuild, removal of the automatic dependency rebuilding

### DIFF
--- a/cmake/CompileGeogram.cmake
+++ b/cmake/CompileGeogram.cmake
@@ -71,5 +71,4 @@ ExternalProject_Add(geogram_ext
 
 ExternalProject_Add_Step(geogram_ext forcebuild
     DEPENDERS build
-    ALWAYS 1
 )

--- a/cmake/CompileMinizip.cmake
+++ b/cmake/CompileMinizip.cmake
@@ -52,5 +52,4 @@ ExternalProject_Add(minizip_ext
 
 ExternalProject_Add_Step(minizip_ext forcebuild
     DEPENDERS build
-    ALWAYS 1
 )

--- a/cmake/CompileRINGMesh.cmake
+++ b/cmake/CompileRINGMesh.cmake
@@ -50,6 +50,5 @@ ExternalProject_Add(ringmesh_ext
 
 ExternalProject_Add_Step(ringmesh_ext forcebuild
     DEPENDERS build
-    ALWAYS 1
   )
 

--- a/cmake/CompileTinyxml2.cmake
+++ b/cmake/CompileTinyxml2.cmake
@@ -58,6 +58,5 @@ ExternalProject_Add(tinyxml2_ext
 
 ExternalProject_Add_Step(tinyxml2_ext forcebuild
     DEPENDERS build
-    ALWAYS 1
 )
 

--- a/cmake/CompileZlib.cmake
+++ b/cmake/CompileZlib.cmake
@@ -57,6 +57,5 @@ ExternalProject_Add(zlib_ext
 
 ExternalProject_Add_Step(zlib_ext forcebuild
     DEPENDERS build
-    ALWAYS 1
 )
 


### PR DESCRIPTION
This old option does not work since the superbuild.