### PR TITLE
Mute warning 4661 of visual

### DIFF
--- a/include/ringmesh/basic/common.h
+++ b/include/ringmesh/basic/common.h
@@ -61,6 +61,7 @@
 #pragma warning( disable : 4250 ) // warning about diamond inheritance
 #pragma warning( disable : 4251 ) // dll interface warnings
 #pragma warning( disable : 4275 ) // let's pray we have no issues
+#pragma warning( disable : 4661 ) // template alias before implementation
 #endif
 
 #define ringmesh_disable_copy( Class )                                         \


### PR DESCRIPTION
The warning is there because we define aliases in the header such as ALIAS_2D_AND_3D( MeshBase ). However, all the methods in MeshBase do not have their implementation yet, there are in the cpp file. Since it is a templated class, the compiler does not like it but since we only allow given explicit instanciated classes, I think this is a false positive warning in our case.