### PR TITLE
fix bug when computing lines from surfaces

### DIFF
--- a/src/ringmesh/geomodel/builder/geomodel_builder.cpp
+++ b/src/ringmesh/geomodel/builder/geomodel_builder.cpp
@@ -701,20 +701,24 @@ namespace
 
         bool vertex_is_on_corner( index_t t, bool backward ) const
         {
-            if( backward )
+            const auto& surfaces = [t, backward, this]{
+                if( backward )
+                {
+                    return surfaces_around_vertices_[this->border_polygons_[t].v1];
+                }
+                else
+                {
+                    return surfaces_around_vertices_[this->border_polygons_[t].v0];
+                }
+            }();
+            for( auto surface : surfaces )
             {
-                return !std::equal(
-                    surfaces_around_vertices_[this->border_polygons_[t].v1].begin(),
-                    surfaces_around_vertices_[this->border_polygons_[t].v1].end(),
-                    cur_line_.adjacent_surfaces_.begin() );
+                if( !contains( cur_line_.adjacent_surfaces_, surface ) )
+                {
+                    return true;
+                }
             }
-            else
-            {
-                return !std::equal(
-                    surfaces_around_vertices_[this->border_polygons_[t].v0].begin(),
-                    surfaces_around_vertices_[this->border_polygons_[t].v0].end(),
-                    cur_line_.adjacent_surfaces_.begin() );
-            }
+            return false;
         }
 
         bool equal_to_line_adjacent_surfaces( index_t t ) const

--- a/src/ringmesh/geomodel/builder/geomodel_builder.cpp
+++ b/src/ringmesh/geomodel/builder/geomodel_builder.cpp
@@ -153,8 +153,8 @@ namespace
     struct BorderPolygon
     {
         BorderPolygon(
-            index_t surface, index_t polygon, index_t v0, index_t v1 )
-            : v0_( v0 ), v1_( v1 ), surface_( surface ), polygon_( polygon )
+            index_t surface_in, index_t polygon_in, index_t v0_in, index_t v1_in )
+            : v0( v0_in ), v1( v1_in ), surface( surface_in ), polygon( polygon_in )
         {
         }
 
@@ -164,35 +164,35 @@ namespace
          */
         bool operator<( const BorderPolygon& rhs ) const
         {
-            if( std::min( v0_, v1_ ) != std::min( rhs.v0_, rhs.v1_ ) )
+            if( std::min( v0, v1 ) != std::min( rhs.v0, rhs.v1 ) )
             {
-                return std::min( v0_, v1_ ) < std::min( rhs.v0_, rhs.v1_ );
+                return std::min( v0, v1 ) < std::min( rhs.v0, rhs.v1 );
             }
-            if( std::max( v0_, v1_ ) != std::max( rhs.v0_, rhs.v1_ ) )
+            if( std::max( v0, v1 ) != std::max( rhs.v0, rhs.v1 ) )
             {
-                return std::max( v0_, v1_ ) < std::max( rhs.v0_, rhs.v1_ );
+                return std::max( v0, v1 ) < std::max( rhs.v0, rhs.v1 );
             }
-            if( surface_ != rhs.surface_ )
+            if( surface != rhs.surface )
             {
-                return surface_ < rhs.surface_;
+                return surface < rhs.surface;
             }
-            return polygon_ < rhs.polygon_;
+            return polygon < rhs.polygon;
         }
 
         bool same_edge( const BorderPolygon& rhs ) const
         {
-            return std::min( v0_, v1_ ) == std::min( rhs.v0_, rhs.v1_ )
-                   && std::max( v0_, v1_ ) == std::max( rhs.v0_, rhs.v1_ );
+            return std::min( v0, v1 ) == std::min( rhs.v0, rhs.v1 )
+                   && std::max( v0, v1 ) == std::max( rhs.v0, rhs.v1 );
         }
 
         /// Indices of the points in the geomodel.
         /// The edge v0v1 is on the one on the boundary.
-        index_t v0_;
-        index_t v1_;
-        // Index of the surface containing the polygon
-        index_t surface_;
-        // Index of the polygon in the surface
-        index_t polygon_;
+        index_t v0;
+        index_t v1;
+        /// Index of the surface containing the polygon
+        index_t surface;
+        /// Index of the polygon in the surface
+        index_t polygon;
     };
 
     template < index_t DIMENSION >
@@ -242,7 +242,7 @@ namespace
 
     protected:
         const GeoModel< DIMENSION >& geomodel_;
-        // All the polygons on a boundary of all the Surfaces of the GeoModel
+        /// All the polygons on a boundary of all the Surfaces of the GeoModel
         std::vector< BorderPolygon > border_polygons_;
     };
 
@@ -523,13 +523,13 @@ namespace
                 {
                     if( line_border.same_edge( border ) )
                     {
-                        auto surface_id = border.surface_;
+                        auto surface_id = border.surface;
                         region_info_[line.index()].add_polygon_edge( surface_id,
                             this->geomodel_.surface( surface_id )
                                 .mesh()
-                                .polygon_normal( border.polygon_ ),
-                            vertices.vertex( border.v0_ ),
-                            vertices.vertex( border.v1_ ) );
+                                .polygon_normal( border.polygon ),
+                            vertices.vertex( border.v0 ),
+                            vertices.vertex( border.v1 ) );
                     }
                 }
                 region_info_[line.index()].sort();
@@ -597,6 +597,13 @@ namespace
               cur_border_polygon_( 0 )
         {
             visited_.resize( this->border_polygons_.size(), false );
+            const auto& geomodel_vertices = this->geomodel_.mesh.vertices;
+            surfaces_around_vertices_.resize( geomodel_vertices.nb() );
+            for( const auto& border : this->border_polygons_ )
+            {
+                fill_surfaces_around_vertex( border.v0 );
+                fill_surfaces_around_vertex( border.v1 );
+            }
         }
 
         /*!
@@ -627,11 +634,26 @@ namespace
         }
 
     private:
+        void fill_surfaces_around_vertex( index_t vertex )
+        {
+            auto& surfaces = surfaces_around_vertices_[vertex];
+            if( !surfaces.empty() )
+            {
+                return;
+            }
+            auto gme_vertices = this->geomodel_.mesh.vertices.gme_type_vertices(
+                surface_type_name_static(), vertex );
+            for( const auto& gme_vertex : gme_vertices )
+            {
+                surfaces.push_back( gme_vertex.gmme.index() );
+            }
+        }
+
         void compute_line_geometry()
         {
             visit_border_polygons_on_same_edge( cur_border_polygon_ );
-            auto p0 = this->border_polygons_[cur_border_polygon_].v0_;
-            auto p1 = this->border_polygons_[cur_border_polygon_].v1_;
+            auto p0 = this->border_polygons_[cur_border_polygon_].v0;
+            auto p1 = this->border_polygons_[cur_border_polygon_].v1;
             cur_line_.vertices_.push_back( p0 );
             cur_line_.vertices_.push_back( p1 );
 
@@ -657,7 +679,7 @@ namespace
 
             auto t = get_next_border_polygon( cur_border_polygon_, backward );
             ringmesh_assert( t != NO_ID );
-            while( propagate( t ) )
+            while( propagate( t, backward ) )
             {
                 visit_border_polygons_on_same_edge( t );
                 add_border_polygon_vertices_to_line( t, backward );
@@ -666,15 +688,33 @@ namespace
             }
         }
 
-        bool propagate( index_t t ) const
+        bool propagate( index_t t, bool backward ) const
         {
             return t != cur_border_polygon_ && !is_visited( t )
-                   && equal_to_line_adjacent_surfaces( t );
+                && equal_to_line_adjacent_surfaces( t ) && !vertex_is_on_corner( t, backward );
         }
 
         bool is_visited( index_t i ) const
         {
             return visited_[i];
+        }
+
+        bool vertex_is_on_corner( index_t t, bool backward ) const
+        {
+            if( backward )
+            {
+                return !std::equal(
+                    surfaces_around_vertices_[this->border_polygons_[t].v1].begin(),
+                    surfaces_around_vertices_[this->border_polygons_[t].v1].end(),
+                    cur_line_.adjacent_surfaces_.begin() );
+            }
+            else
+            {
+                return !std::equal(
+                    surfaces_around_vertices_[this->border_polygons_[t].v0].begin(),
+                    surfaces_around_vertices_[this->border_polygons_[t].v0].end(),
+                    cur_line_.adjacent_surfaces_.begin() );
+            }
         }
 
         bool equal_to_line_adjacent_surfaces( index_t t ) const
@@ -693,7 +733,7 @@ namespace
         {
             const auto& border_polygon = this->border_polygons_[polygon_index];
             add_vertices_to_line(
-                border_polygon.v0_, border_polygon.v1_, !backward );
+                border_polygon.v0, border_polygon.v1, !backward );
         }
 
         void add_vertices_to_line( index_t v0, index_t v1, bool at_the_end )
@@ -734,15 +774,15 @@ namespace
         index_t get_next_border_polygon( index_t from, bool backward ) const
         {
             const auto& border_polygon = this->border_polygons_[from];
-            const auto& S = this->geomodel_.surface( border_polygon.surface_ );
+            const auto& S = this->geomodel_.surface( border_polygon.surface );
             const auto& mesh = S.mesh();
             auto surface_id = S.gmme();
             const auto& geomodel_vertices = this->geomodel_.mesh.vertices;
 
             // Gets the next edge on border in the Surface
-            auto p = border_polygon.polygon_;
+            auto p = border_polygon.polygon;
             auto possible_v0_id = geomodel_vertices.mesh_entity_vertex_id(
-                surface_id, border_polygon.v0_ );
+                surface_id, border_polygon.v0 );
             ringmesh_assert( !possible_v0_id.empty() );
             index_t v0_id{ NO_ID };
             for( auto id : possible_v0_id )
@@ -775,7 +815,7 @@ namespace
 
             // Finds the BorderPolygon that is corresponding to this
             // It must exist and there is only one
-            BorderPolygon bait{ border_polygon.surface_,
+            BorderPolygon bait{ border_polygon.surface,
                 next_polygon_local_edge0_on_border.polygon_id,
                 geomodel_vertices.geomodel_vertex_id(
                     surface_id, next_polygon_local_edge0_on_border ),
@@ -824,7 +864,7 @@ namespace
             std::vector< index_t > adjacent_surfaces;
             adjacent_surfaces.reserve( 10 );
             adjacent_surfaces.push_back(
-                this->border_polygons_[border_id].surface_ );
+                this->border_polygons_[border_id].surface );
 
             for( auto next_border_id = border_id + 1;
                  next_border_id < this->border_polygons_.size()
@@ -833,7 +873,7 @@ namespace
                  next_border_id++ )
             {
                 adjacent_surfaces.push_back(
-                    this->border_polygons_[next_border_id].surface_ );
+                    this->border_polygons_[next_border_id].surface );
             }
 
             for( auto prev_border_id = border_id - 1;
@@ -843,18 +883,20 @@ namespace
                  prev_border_id-- )
             {
                 adjacent_surfaces.push_back(
-                    this->border_polygons_[prev_border_id].surface_ );
+                    this->border_polygons_[prev_border_id].surface );
             }
             std::sort( adjacent_surfaces.begin(), adjacent_surfaces.end() );
             return adjacent_surfaces;
         }
 
     private:
-        // Internal use to flag the visited border_polygons when computing the
-        // Lines
+        /// Flag the visited border_polygons when computing the Lines
         std::vector< bool > visited_;
 
-        // Currently computed line information
+        /// Surfaces around vertices (only filled for boundary vertices)
+        std::vector< std::vector< index_t > > surfaces_around_vertices_;
+
+        /// Currently computed line information
         index_t cur_border_polygon_;
         LineDefinition cur_line_;
     };

--- a/tests/geomodel/core/test-get-dependent-entities.cpp
+++ b/tests/geomodel/core/test-get-dependent-entities.cpp
@@ -51,28 +51,26 @@
 
 using namespace RINGMesh;
 
-template < typename GME >
+template< typename GME >
 void check_element_of_a_set_are_in_another_set(
     const std::set< GME >& to_compare,
     const std::set< GME >& with,
     const std::string& set_name )
 {
-    if( to_compare != with )
-    {
+    if( to_compare != with ) {
         // To debug it is nice to know which entity fails...
-        for( const GME& cur_gme_id : to_compare )
-        {
-            if( find( with.begin(), with.end(), cur_gme_id ) == with.end() )
-            {
-                throw RINGMeshException( "RINGMesh Test", cur_gme_id.type(),
-                    " ", cur_gme_id.index(), " is not in the ", set_name, "." );
+        for( const GME& cur_gme_id : to_compare ) {
+            if( find( with.begin(), with.end(), cur_gme_id ) == with.end() ) {
+                throw RINGMeshException( "RINGMesh Test", cur_gme_id.type(), " ",
+                    cur_gme_id.index(), " is not in the ", set_name, "." );
             }
         }
         ringmesh_assert_not_reached;
     }
 }
 
-void test_template( GeoModel3D& geomodel,
+void test_template(
+    GeoModel3D& geomodel,
     const std::set< gmme_id >& solution_gmme_id,
     const std::set< gmge_id >& solution_gmge_id,
     const std::string& to_insert_type,
@@ -84,83 +82,67 @@ void test_template( GeoModel3D& geomodel,
 
     const MeshEntityType mesh_type( to_insert_type );
     if( geomodel.entity_type_manager().mesh_entity_manager.is_valid_type(
-            mesh_type ) )
-    {
+        mesh_type ) ) {
         in_mesh_entities.insert( { mesh_type, to_insert_id } );
-    }
-    else
-    {
+    } else {
         const GeologicalEntityType geological_type( to_insert_type );
         ringmesh_assert(
-            geomodel.entity_type_manager()
-                .geological_entity_manager.is_valid_type( geological_type ) );
+            geomodel.entity_type_manager().geological_entity_manager.is_valid_type(
+                geological_type ) );
         in_geological_entities.insert( { geological_type, to_insert_id } );
     }
 
     const GeoModelBuilder3D geomodel_builder( geomodel );
-    geomodel_builder.topology.get_dependent_entities(
-        in_mesh_entities, in_geological_entities );
-    check_element_of_a_set_are_in_another_set< gmme_id >(
-        in_mesh_entities, solution_gmme_id, "solution" );
-    check_element_of_a_set_are_in_another_set< gmge_id >(
-        in_geological_entities, solution_gmge_id, "solution" );
-    check_element_of_a_set_are_in_another_set< gmme_id >(
-        solution_gmme_id, in_mesh_entities, "output" );
-    check_element_of_a_set_are_in_another_set< gmge_id >(
-        solution_gmge_id, in_geological_entities, "output" );
+    geomodel_builder.topology.get_dependent_entities( in_mesh_entities,
+        in_geological_entities );
+    check_element_of_a_set_are_in_another_set< gmme_id >( in_mesh_entities,
+        solution_gmme_id, "solution" );
+    check_element_of_a_set_are_in_another_set< gmge_id >( in_geological_entities,
+        solution_gmge_id, "solution" );
+    check_element_of_a_set_are_in_another_set< gmme_id >( solution_gmme_id,
+        in_mesh_entities, "output" );
+    check_element_of_a_set_are_in_another_set< gmge_id >( solution_gmge_id,
+        in_geological_entities, "output" );
+}
+
+template< class ENTITY, typename T >
+void add_entities_in_set( std::set< T >& set )
+{
+    // Do nothing
+    ringmesh_unused( set );
+}
+
+template< class ENTITY, typename T >
+void add_entity_in_set( std::set< T >& set, int entity_id )
+{
+    set.emplace( ENTITY::type_name_static(), entity_id );
+}
+
+template< class ENTITY, typename T, typename ... Args >
+void add_entities_in_set(
+    std::set< T >& set,
+    const int& first_id,
+    const Args&... other_ids )
+{
+    add_entity_in_set< ENTITY >( set, first_id );
+    add_entities_in_set< ENTITY >( set, other_ids... );
 }
 
 void test_on_top_region( GeoModel3D& geomodel )
 {
-    std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(),
-                                                 31 },
-        { Corner3D::type_name_static(), 33 },
-        { Corner3D::type_name_static(), 54 },
-        { Corner3D::type_name_static(), 55 },
-        { Corner3D::type_name_static(), 56 },
-        { Corner3D::type_name_static(), 57 },
-        { Corner3D::type_name_static(), 58 },
-        { Corner3D::type_name_static(), 99 },
-        { Corner3D::type_name_static(), 125 },
-        { Corner3D::type_name_static(), 138 },
-        { Corner3D::type_name_static(), 139 },
-        { Line3D::type_name_static(), 41 }, { Line3D::type_name_static(), 43 },
-        { Line3D::type_name_static(), 68 }, { Line3D::type_name_static(), 69 },
-        { Line3D::type_name_static(), 70 }, { Line3D::type_name_static(), 71 },
-        { Line3D::type_name_static(), 72 }, { Line3D::type_name_static(), 73 },
-        { Line3D::type_name_static(), 137 },
-        { Line3D::type_name_static(), 141 },
-        { Line3D::type_name_static(), 151 },
-        { Line3D::type_name_static(), 184 },
-        { Line3D::type_name_static(), 189 },
-        { Line3D::type_name_static(), 213 },
-        { Line3D::type_name_static(), 215 },
-        { Line3D::type_name_static(), 217 },
-        { Line3D::type_name_static(), 220 },
-        { Line3D::type_name_static(), 243 },
-        { Line3D::type_name_static(), 244 },
-        { Line3D::type_name_static(), 248 },
-        { Surface3D::type_name_static(), 11 },
-        { Surface3D::type_name_static(), 37 },
-        { Surface3D::type_name_static(), 40 },
-        { Surface3D::type_name_static(), 60 },
-        { Surface3D::type_name_static(), 85 },
-        { Surface3D::type_name_static(), 91 },
-        { Surface3D::type_name_static(), 99 },
-        { Surface3D::type_name_static(), 110 },
-        { Surface3D::type_name_static(), 114 },
-        { Region3D::type_name_static(), 4 } };
+    std::set< gmme_id > solution_gmme_id;
+    add_entities_in_set< Corner3D >( solution_gmme_id, 31, 33, 54, 55, 56, 57, 58,
+        99, 125, 138, 139 );
+    add_entities_in_set< Line3D >( solution_gmme_id, 41, 43, 68, 69, 70, 71, 72, 73,
+        137, 141, 151, 184, 189, 213, 215, 217, 220, 243, 244, 248 );
+    add_entities_in_set< Surface3D >( solution_gmme_id, 11, 37, 40, 60, 85, 91, 99,
+        110, 114 );
+    add_entities_in_set< Region3D >( solution_gmme_id, 4 );
 
-    std::set< gmge_id > solution_gmge_id = {
-        { Contact3D::type_name_static(), 26 },
-        { Contact3D::type_name_static(), 27 },
-        { Contact3D::type_name_static(), 28 },
-        { Contact3D::type_name_static(), 78 },
-        { Contact3D::type_name_static(), 79 },
-        { Contact3D::type_name_static(), 83 },
-        { Interface3D::type_name_static(), 21 },
-        { Layer3D::type_name_static(), 0 },
-    };
+    std::set< gmge_id > solution_gmge_id;
+    add_entities_in_set< Contact3D >( solution_gmge_id, 26, 27, 28, 78, 79, 83 );
+    add_entities_in_set< Interface3D >( solution_gmge_id, 21 );
+    add_entities_in_set< Layer3D >( solution_gmge_id, 0 );
 
     test_template( geomodel, solution_gmme_id, solution_gmge_id,
         Region3D::type_name_static().string(), 4 );
@@ -169,12 +151,11 @@ void test_on_top_region( GeoModel3D& geomodel )
 void test_on_surface_within_bottom_region_partially_connected_to_voi(
     GeoModel3D& geomodel )
 {
-    std::set< gmme_id > solution_gmme_id = { { Line3D::type_name_static(), 103 },
-        { Surface3D::type_name_static(), 24 } };
+    std::set< gmme_id > solution_gmme_id = { { Line3D::type_name_static(), 103 }, {
+        Surface3D::type_name_static(), 24 } };
 
-    std::set< gmge_id > solution_gmge_id = { { Contact3D::type_name_static(),
-                                                 36 },
-        { Interface3D::type_name_static(), 3 } };
+    std::set< gmge_id > solution_gmge_id = { { Contact3D::type_name_static(), 36 }, {
+        Interface3D::type_name_static(), 3 } };
 
     test_template( geomodel, solution_gmme_id, solution_gmge_id,
         Surface3D::type_name_static().string(), 24 );
@@ -182,21 +163,12 @@ void test_on_surface_within_bottom_region_partially_connected_to_voi(
 
 void test_on_fault_not_connected_to_any_surface( GeoModel3D& geomodel )
 {
-    std::set< gmme_id > solution_gmme_id = { { Line3D::type_name_static(),
-                                                 170 },
-        { Line3D::type_name_static(), 172 },
-        { Line3D::type_name_static(), 173 },
-        { Line3D::type_name_static(), 175 },
-        { Surface3D::type_name_static(), 52 },
-        { Surface3D::type_name_static(), 53 },
-        { Surface3D::type_name_static(), 54 },
-        { Surface3D::type_name_static(), 55 },
-        { Surface3D::type_name_static(), 56 },
-        { Surface3D::type_name_static(), 57 } };
+    std::set< gmme_id > solution_gmme_id;
+    add_entities_in_set< Line3D >( solution_gmme_id, 170, 172, 173, 175 );
+    add_entities_in_set< Surface3D >( solution_gmme_id, 52, 53, 54, 55, 56, 57 );
 
-    std::set< gmge_id > solution_gmge_id = { { Contact3D::type_name_static(),
-                                                 55 },
-        { Interface3D::type_name_static(), 8 } };
+    std::set< gmge_id > solution_gmge_id = { { Contact3D::type_name_static(), 55 }, {
+        Interface3D::type_name_static(), 8 } };
 
     test_template( geomodel, solution_gmme_id, solution_gmge_id,
         Interface3D::type_name_static().string(), 8 );
@@ -204,9 +176,9 @@ void test_on_fault_not_connected_to_any_surface( GeoModel3D& geomodel )
 
 void test_on_corner_on_botom_corner_voi( GeoModel3D& geomodel )
 {
-    std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(),
-        135 } };
+    std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(), 135 } };
 
+    // No entity
     std::set< gmge_id > solution_gmge_id;
 
     test_template( geomodel, solution_gmme_id, solution_gmge_id,
@@ -215,55 +187,20 @@ void test_on_corner_on_botom_corner_voi( GeoModel3D& geomodel )
 
 void test_on_top_layer( GeoModel3D& geomodel )
 {
-    std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(),
-                                                 31 },
-        { Corner3D::type_name_static(), 33 },
-        { Corner3D::type_name_static(), 54 },
-        { Corner3D::type_name_static(), 55 },
-        { Corner3D::type_name_static(), 56 },
-        { Corner3D::type_name_static(), 57 },
-        { Corner3D::type_name_static(), 58 },
-        { Corner3D::type_name_static(), 99 },
-        { Corner3D::type_name_static(), 125 },
-        { Corner3D::type_name_static(), 138 },
-        { Corner3D::type_name_static(), 139 },
-        { Line3D::type_name_static(), 41 }, { Line3D::type_name_static(), 43 },
-        { Line3D::type_name_static(), 68 }, { Line3D::type_name_static(), 69 },
-        { Line3D::type_name_static(), 70 }, { Line3D::type_name_static(), 71 },
-        { Line3D::type_name_static(), 72 }, { Line3D::type_name_static(), 73 },
-        { Line3D::type_name_static(), 137 },
-        { Line3D::type_name_static(), 141 },
-        { Line3D::type_name_static(), 151 },
-        { Line3D::type_name_static(), 184 },
-        { Line3D::type_name_static(), 189 },
-        { Line3D::type_name_static(), 213 },
-        { Line3D::type_name_static(), 215 },
-        { Line3D::type_name_static(), 217 },
-        { Line3D::type_name_static(), 220 },
-        { Line3D::type_name_static(), 243 },
-        { Line3D::type_name_static(), 244 },
-        { Line3D::type_name_static(), 248 },
-        { Surface3D::type_name_static(), 11 },
-        { Surface3D::type_name_static(), 37 },
-        { Surface3D::type_name_static(), 40 },
-        { Surface3D::type_name_static(), 60 },
-        { Surface3D::type_name_static(), 85 },
-        { Surface3D::type_name_static(), 91 },
-        { Surface3D::type_name_static(), 99 },
-        { Surface3D::type_name_static(), 110 },
-        { Surface3D::type_name_static(), 114 },
-        { Region3D::type_name_static(), 4 } };
 
-    std::set< gmge_id > solution_gmge_id = {
-        { Contact3D::type_name_static(), 26 },
-        { Contact3D::type_name_static(), 27 },
-        { Contact3D::type_name_static(), 28 },
-        { Contact3D::type_name_static(), 78 },
-        { Contact3D::type_name_static(), 79 },
-        { Contact3D::type_name_static(), 83 },
-        { Interface3D::type_name_static(), 21 },
-        { Layer3D::type_name_static(), 0 },
-    };
+    std::set< gmme_id > solution_gmme_id;
+    add_entities_in_set< Corner3D >( solution_gmme_id, 31, 33, 54, 55, 56, 57, 58,
+        99, 125, 138, 139 );
+    add_entities_in_set< Line3D >( solution_gmme_id, 41, 43, 68, 69, 70, 71, 72, 73,
+        137, 141, 151, 184, 189, 213, 215, 217, 220, 243, 244, 248 );
+    add_entities_in_set< Surface3D >( solution_gmme_id, 11, 37, 40, 60, 85, 91, 99,
+        110, 114 );
+    add_entities_in_set< Region3D >( solution_gmme_id, 4 );
+
+    std::set< gmge_id > solution_gmge_id;
+    add_entities_in_set< Contact3D >( solution_gmge_id, 26, 27, 28, 78, 79, 83 );
+    add_entities_in_set< Interface3D >( solution_gmge_id, 21 );
+    add_entities_in_set< Layer3D >( solution_gmge_id, 0 );
 
     test_template( geomodel, solution_gmme_id, solution_gmge_id,
         Layer3D::type_name_static().string(), 0 );
@@ -280,7 +217,7 @@ void run_tests( GeoModel3D& geomodel )
 
 void load_geomodel( GeoModel3D& geomodel )
 {
-    std::string file_name{ ringmesh_test_data_path };
+    std::string file_name { ringmesh_test_data_path };
     file_name += "CloudSpin_fixed.ml";
 
     // No validity checks at loading
@@ -292,22 +229,17 @@ void load_geomodel( GeoModel3D& geomodel )
 
 int main()
 {
-    try
-    {
-        Logger::out(
-            "TEST", "Test GeoModelBuilderTopology::get_dependent_entities" );
+    try {
+        Logger::out( "TEST",
+            "Test GeoModelBuilderTopology::get_dependent_entities" );
 
         GeoModel3D geomodel;
         load_geomodel( geomodel );
         run_tests( geomodel );
-    }
-    catch( const RINGMeshException& e )
-    {
+    } catch( const RINGMeshException& e ) {
         Logger::err( e.category(), e.what() );
         return 1;
-    }
-    catch( const std::exception& e )
-    {
+    } catch( const std::exception& e ) {
         Logger::err( "Exception", e.what() );
         return 1;
     }

--- a/tests/geomodel/core/test-get-dependent-entities.cpp
+++ b/tests/geomodel/core/test-get-dependent-entities.cpp
@@ -112,12 +112,6 @@ void test_template( GeoModel3D& geomodel,
 
 void test_on_top_region( GeoModel3D& geomodel )
 {
-    // Solution:
-    // Corners: 31, 33, 54, 55, 56, 57, 58, 99, 125, 138, 139.
-    // Lines: 41, 43, 68, 69, 70, 71, 72, 73, 137, 141, 151, 184, 189, 213, 215,
-    // 217, 220, 243, 244, 248.
-    // Surfaces: 11, 37, 40, 60, 85, 91, 99, 110, 114.
-    // Region: 4.
     std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(),
                                                  31 },
         { Corner3D::type_name_static(), 33 },
@@ -157,10 +151,6 @@ void test_on_top_region( GeoModel3D& geomodel )
         { Surface3D::type_name_static(), 114 },
         { Region3D::type_name_static(), 4 } };
 
-    // Solution:
-    // Contacts: 26, 27, 28, 78, 79, 83.
-    // Interface: 21.
-    // Layer: 0.
     std::set< gmge_id > solution_gmge_id = {
         { Contact3D::type_name_static(), 26 },
         { Contact3D::type_name_static(), 27 },
@@ -179,18 +169,9 @@ void test_on_top_region( GeoModel3D& geomodel )
 void test_on_surface_within_bottom_region_partially_connected_to_voi(
     GeoModel3D& geomodel )
 {
-    // Solution:
-    // Corner: none.
-    // Line: 103.
-    // Surface: 24.
-    // Region: none.
     std::set< gmme_id > solution_gmme_id = { { Line3D::type_name_static(), 103 },
         { Surface3D::type_name_static(), 24 } };
 
-    // Solution:
-    // Contact: 36.
-    // Interface: 3.
-    // Layer: none.
     std::set< gmge_id > solution_gmge_id = { { Contact3D::type_name_static(),
                                                  36 },
         { Interface3D::type_name_static(), 3 } };
@@ -201,11 +182,6 @@ void test_on_surface_within_bottom_region_partially_connected_to_voi(
 
 void test_on_fault_not_connected_to_any_surface( GeoModel3D& geomodel )
 {
-    // Solution:
-    // Corner: none.
-    // Lines: 170, 172, 173, 175.
-    // Surfaces: 52, 53, 54, 55, 56, 57.
-    // Region: none.
     std::set< gmme_id > solution_gmme_id = { { Line3D::type_name_static(),
                                                  170 },
         { Line3D::type_name_static(), 172 },
@@ -218,10 +194,6 @@ void test_on_fault_not_connected_to_any_surface( GeoModel3D& geomodel )
         { Surface3D::type_name_static(), 56 },
         { Surface3D::type_name_static(), 57 } };
 
-    // Solution:
-    // Contact: 55.
-    // Interface: 8.
-    // Layer: none.
     std::set< gmge_id > solution_gmge_id = { { Contact3D::type_name_static(),
                                                  55 },
         { Interface3D::type_name_static(), 8 } };
@@ -232,18 +204,9 @@ void test_on_fault_not_connected_to_any_surface( GeoModel3D& geomodel )
 
 void test_on_corner_on_botom_corner_voi( GeoModel3D& geomodel )
 {
-    // Solution:
-    // Corner: 135.
-    // Line: none.
-    // Surface: none.
-    // Region: none.
     std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(),
         135 } };
 
-    // Solution:
-    // Contact: none.
-    // Interface: none.
-    // Layer: none.
     std::set< gmge_id > solution_gmge_id;
 
     test_template( geomodel, solution_gmme_id, solution_gmge_id,
@@ -252,12 +215,6 @@ void test_on_corner_on_botom_corner_voi( GeoModel3D& geomodel )
 
 void test_on_top_layer( GeoModel3D& geomodel )
 {
-    // Solution:
-    // Corners: 31, 33, 54, 55, 56, 57, 58, 99, 125, 138, 139.
-    // Lines: 41, 43, 68, 69, 70, 71, 72, 73, 137, 141, 151, 184, 189, 213, 215,
-    // 217, 220, 243, 244, 248.
-    // Surfaces: 11, 37, 40, 60, 85, 91, 99, 110, 114.
-    // Region: 4.
     std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(),
                                                  31 },
         { Corner3D::type_name_static(), 33 },
@@ -297,10 +254,6 @@ void test_on_top_layer( GeoModel3D& geomodel )
         { Surface3D::type_name_static(), 114 },
         { Region3D::type_name_static(), 4 } };
 
-    // Solution:
-    // Contacts: 26, 27, 28, 78, 79, 83.
-    // Interface: 21.
-    // Layer: 0.
     std::set< gmge_id > solution_gmge_id = {
         { Contact3D::type_name_static(), 26 },
         { Contact3D::type_name_static(), 27 },

--- a/tests/geomodel/core/test-get-dependent-entities.cpp
+++ b/tests/geomodel/core/test-get-dependent-entities.cpp
@@ -112,19 +112,13 @@ void add_entities_in_set( std::set< T >& set )
     ringmesh_unused( set );
 }
 
-template< class ENTITY, typename T >
-void add_entity_in_set( std::set< T >& set, int entity_id )
-{
-    set.emplace( ENTITY::type_name_static(), entity_id );
-}
-
 template< class ENTITY, typename T, typename ... Args >
 void add_entities_in_set(
     std::set< T >& set,
     const int& first_id,
     const Args&... other_ids )
 {
-    add_entity_in_set< ENTITY >( set, first_id );
+    set.emplace( ENTITY::type_name_static(), first_id );
     add_entities_in_set< ENTITY >( set, other_ids... );
 }
 

--- a/tests/geomodel/core/test-get-dependent-entities.cpp
+++ b/tests/geomodel/core/test-get-dependent-entities.cpp
@@ -35,6 +35,8 @@
 
 #include <ringmesh/ringmesh_tests_config.h>
 
+#include <geogram/basic/command_line.h>
+
 #include <ringmesh/basic/algorithm.h>
 #include <ringmesh/geomodel/builder/geomodel_builder.h>
 #include <ringmesh/geomodel/core/geomodel.h>
@@ -111,9 +113,9 @@ void test_template( GeoModel3D& geomodel,
 void test_on_top_region( GeoModel3D& geomodel )
 {
     // Solution:
-    // Corners: 31, 33, 54, 55, 56, 57, 58, 93, 118, 128, 129.
-    // Lines: 41, 43, 68, 69, 70, 71, 72, 73, 131, 135, 144, 177, 182, 203, 205,
-    // 207, 210, 233, 234, 238.
+    // Corners: 31, 33, 54, 55, 56, 57, 58, 99, 125, 138, 139.
+    // Lines: 41, 43, 68, 69, 70, 71, 72, 73, 137, 141, 151, 184, 189, 213, 215,
+    // 217, 220, 243, 244, 248.
     // Surfaces: 11, 37, 40, 60, 85, 91, 99, 110, 114.
     // Region: 4.
     std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(),
@@ -124,26 +126,26 @@ void test_on_top_region( GeoModel3D& geomodel )
         { Corner3D::type_name_static(), 56 },
         { Corner3D::type_name_static(), 57 },
         { Corner3D::type_name_static(), 58 },
-        { Corner3D::type_name_static(), 93 },
-        { Corner3D::type_name_static(), 118 },
-        { Corner3D::type_name_static(), 128 },
-        { Corner3D::type_name_static(), 129 },
+        { Corner3D::type_name_static(), 99 },
+        { Corner3D::type_name_static(), 125 },
+        { Corner3D::type_name_static(), 138 },
+        { Corner3D::type_name_static(), 139 },
         { Line3D::type_name_static(), 41 }, { Line3D::type_name_static(), 43 },
         { Line3D::type_name_static(), 68 }, { Line3D::type_name_static(), 69 },
         { Line3D::type_name_static(), 70 }, { Line3D::type_name_static(), 71 },
         { Line3D::type_name_static(), 72 }, { Line3D::type_name_static(), 73 },
-        { Line3D::type_name_static(), 131 },
-        { Line3D::type_name_static(), 135 },
-        { Line3D::type_name_static(), 144 },
-        { Line3D::type_name_static(), 177 },
-        { Line3D::type_name_static(), 182 },
-        { Line3D::type_name_static(), 203 },
-        { Line3D::type_name_static(), 205 },
-        { Line3D::type_name_static(), 207 },
-        { Line3D::type_name_static(), 210 },
-        { Line3D::type_name_static(), 233 },
-        { Line3D::type_name_static(), 234 },
-        { Line3D::type_name_static(), 238 },
+        { Line3D::type_name_static(), 137 },
+        { Line3D::type_name_static(), 141 },
+        { Line3D::type_name_static(), 151 },
+        { Line3D::type_name_static(), 184 },
+        { Line3D::type_name_static(), 189 },
+        { Line3D::type_name_static(), 213 },
+        { Line3D::type_name_static(), 215 },
+        { Line3D::type_name_static(), 217 },
+        { Line3D::type_name_static(), 220 },
+        { Line3D::type_name_static(), 243 },
+        { Line3D::type_name_static(), 244 },
+        { Line3D::type_name_static(), 248 },
         { Surface3D::type_name_static(), 11 },
         { Surface3D::type_name_static(), 37 },
         { Surface3D::type_name_static(), 40 },
@@ -179,10 +181,10 @@ void test_on_surface_within_bottom_region_partially_connected_to_voi(
 {
     // Solution:
     // Corner: none.
-    // Line: 98.
+    // Line: 103.
     // Surface: 24.
     // Region: none.
-    std::set< gmme_id > solution_gmme_id = { { Line3D::type_name_static(), 98 },
+    std::set< gmme_id > solution_gmme_id = { { Line3D::type_name_static(), 103 },
         { Surface3D::type_name_static(), 24 } };
 
     // Solution:
@@ -201,14 +203,14 @@ void test_on_fault_not_connected_to_any_surface( GeoModel3D& geomodel )
 {
     // Solution:
     // Corner: none.
-    // Lines: 163, 165, 166, 168.
+    // Lines: 170, 172, 173, 175.
     // Surfaces: 52, 53, 54, 55, 56, 57.
     // Region: none.
     std::set< gmme_id > solution_gmme_id = { { Line3D::type_name_static(),
-                                                 163 },
-        { Line3D::type_name_static(), 165 },
-        { Line3D::type_name_static(), 166 },
-        { Line3D::type_name_static(), 168 },
+                                                 170 },
+        { Line3D::type_name_static(), 172 },
+        { Line3D::type_name_static(), 173 },
+        { Line3D::type_name_static(), 175 },
         { Surface3D::type_name_static(), 52 },
         { Surface3D::type_name_static(), 53 },
         { Surface3D::type_name_static(), 54 },
@@ -251,9 +253,9 @@ void test_on_corner_on_botom_corner_voi( GeoModel3D& geomodel )
 void test_on_top_layer( GeoModel3D& geomodel )
 {
     // Solution:
-    // Corners: 31, 33, 54, 55, 56, 57, 58, 93, 118, 128, 129.
-    // Lines: 41, 43, 68, 69, 70, 71, 72, 73, 131, 135, 144, 177, 182, 203, 205,
-    // 207, 210, 233, 234, 238.
+    // Corners: 31, 33, 54, 55, 56, 57, 58, 99, 125, 138, 139.
+    // Lines: 41, 43, 68, 69, 70, 71, 72, 73, 137, 141, 151, 184, 189, 213, 215,
+    // 217, 220, 243, 244, 248.
     // Surfaces: 11, 37, 40, 60, 85, 91, 99, 110, 114.
     // Region: 4.
     std::set< gmme_id > solution_gmme_id = { { Corner3D::type_name_static(),
@@ -264,26 +266,26 @@ void test_on_top_layer( GeoModel3D& geomodel )
         { Corner3D::type_name_static(), 56 },
         { Corner3D::type_name_static(), 57 },
         { Corner3D::type_name_static(), 58 },
-        { Corner3D::type_name_static(), 93 },
-        { Corner3D::type_name_static(), 118 },
-        { Corner3D::type_name_static(), 128 },
-        { Corner3D::type_name_static(), 129 },
+        { Corner3D::type_name_static(), 99 },
+        { Corner3D::type_name_static(), 125 },
+        { Corner3D::type_name_static(), 138 },
+        { Corner3D::type_name_static(), 139 },
         { Line3D::type_name_static(), 41 }, { Line3D::type_name_static(), 43 },
         { Line3D::type_name_static(), 68 }, { Line3D::type_name_static(), 69 },
         { Line3D::type_name_static(), 70 }, { Line3D::type_name_static(), 71 },
         { Line3D::type_name_static(), 72 }, { Line3D::type_name_static(), 73 },
-        { Line3D::type_name_static(), 131 },
-        { Line3D::type_name_static(), 135 },
-        { Line3D::type_name_static(), 144 },
-        { Line3D::type_name_static(), 177 },
-        { Line3D::type_name_static(), 182 },
-        { Line3D::type_name_static(), 203 },
-        { Line3D::type_name_static(), 205 },
-        { Line3D::type_name_static(), 207 },
-        { Line3D::type_name_static(), 210 },
-        { Line3D::type_name_static(), 233 },
-        { Line3D::type_name_static(), 234 },
-        { Line3D::type_name_static(), 238 },
+        { Line3D::type_name_static(), 137 },
+        { Line3D::type_name_static(), 141 },
+        { Line3D::type_name_static(), 151 },
+        { Line3D::type_name_static(), 184 },
+        { Line3D::type_name_static(), 189 },
+        { Line3D::type_name_static(), 213 },
+        { Line3D::type_name_static(), 215 },
+        { Line3D::type_name_static(), 217 },
+        { Line3D::type_name_static(), 220 },
+        { Line3D::type_name_static(), 243 },
+        { Line3D::type_name_static(), 244 },
+        { Line3D::type_name_static(), 248 },
         { Surface3D::type_name_static(), 11 },
         { Surface3D::type_name_static(), 37 },
         { Surface3D::type_name_static(), 40 },
@@ -328,13 +330,11 @@ void load_geomodel( GeoModel3D& geomodel )
     std::string file_name{ ringmesh_test_data_path };
     file_name += "CloudSpin_fixed.ml";
 
+    // No validity checks at loading
+    GEO::CmdLine::set_arg( "validity:do_not_check", "A" );
+
     // Load the model
-    auto init_model_is_valid = geomodel_load( geomodel, file_name );
-    if( !init_model_is_valid )
-    {
-        throw RINGMeshException( "RINGMesh Test", "Input test model ",
-            geomodel.name(), " must be valid." );
-    }
+    geomodel_load( geomodel, file_name );
 }
 
 int main()

--- a/tests/io/data/load/CloudSpin_fixed.ml.txt
+++ b/tests/io/data/load/CloudSpin_fixed.ml.txt
@@ -1,5 +1,5 @@
-Corner 138
-Line 239
+Corner 148
+Line 249
 Surface 115
 Region 7
 Vertex 14524

--- a/tests/io/data/load/modelA4_lts.so.txt
+++ b/tests/io/data/load/modelA4_lts.so.txt
@@ -1,5 +1,5 @@
-Corner 60
-Line 106
+Corner 52
+Line 98
 Surface 55
 Region 8
 Vertex 6691

--- a/tests/io/data/load/modelA4_lts.so.txt
+++ b/tests/io/data/load/modelA4_lts.so.txt
@@ -1,5 +1,5 @@
-Corner 52
-Line 98
+Corner 60
+Line 106
 Surface 55
 Region 8
 Vertex 6691


### PR DESCRIPTION
The old algorithm defines a segment line by its radial surfaces. However, a line can cross another surface and intersect only by a vertex. In this case, the previous deifnition is still valid but we are suppose to create a new line.