### PR TITLE
correction of the number of edges per line

### DIFF
--- a/src/ringmesh/geomodel/core/geomodel_mesh.cpp
+++ b/src/ringmesh/geomodel/core/geomodel_mesh.cpp
@@ -2044,7 +2044,7 @@ namespace RINGMesh
     {
         test_and_initialize();
         ringmesh_assert( line < this->geomodel_.nb_lines() );
-        return line_edge_ptr_[line + 1];
+        return line_edge_ptr_[line + 1] - line_edge_ptr_[line];
     }
 
     template < index_t DIMENSION >


### PR DESCRIPTION
The number of edges per line was constantly growing. This withdraw the number of edges in the previous line to correct the mistake.