### PR TITLE
Fix distance evalution in mesh_aabb

### DIFF
--- a/src/ringmesh/mesh/mesh_aabb.cpp
+++ b/src/ringmesh/mesh/mesh_aabb.cpp
@@ -115,7 +115,7 @@ namespace RINGMesh
     double LineAABBTree< DIMENSION >::DistanceToEdge::operator()(
         const vecn< DIMENSION >& pt1, const vecn< DIMENSION >& pt2 ) const
     {
-        return length2( pt1 - pt2 );
+        return length( pt1 - pt2 );
     }
 
     template < index_t DIMENSION >
@@ -172,7 +172,7 @@ namespace RINGMesh
     double SurfaceAABBTree< DIMENSION >::DistanceToTriangle::operator()(
         const vecn< DIMENSION >& pt1, const vecn< DIMENSION >& pt2 ) const
     {
-        return length2( pt1 - pt2 );
+        return length( pt1 - pt2 );
     }
 
     template < index_t DIMENSION >


### PR DESCRIPTION
Thanks to Hugo for finding this mistake. The squared distance is returned instead of the distance.